### PR TITLE
Improve adding conditions

### DIFF
--- a/src/Evaluables/Evaluators/Evaluator.php
+++ b/src/Evaluables/Evaluators/Evaluator.php
@@ -291,7 +291,7 @@ class Evaluator
             # string keys might indicate that is the name/alias of the condition
             if (is_string($key)) {
                 $this->defineCondition($key, $condition);
-            }else {
+            } else {
                 $this->defineFromClass($condition);
             }
         }
@@ -312,7 +312,8 @@ class Evaluator
      *
      * @return array
      */
-    protected function flattenDataSource(array $datasource, $prefix = '') {
+    protected function flattenDataSource(array $datasource, $prefix = '')
+    {
         $flatten = [];
 
         foreach ($datasource as $key => $value) {

--- a/src/Evaluables/Evaluators/Evaluator.php
+++ b/src/Evaluables/Evaluators/Evaluator.php
@@ -16,6 +16,10 @@ class Evaluator
 
     const NOT_CONNECTOR = 'not';
 
+    const TYPE_CONDITION = 'condition';
+
+    const TYPE_GROUP = 'group';
+
     /**
      * Prefix for identify which argument should be pull
      * from the datasource
@@ -192,33 +196,40 @@ class Evaluator
 
     public function addGroup(array $conditions, string $connector = self::AND_CONNECTOR, $negate = false)
     {
-        return $this->_group(function ($evaluator) use ($conditions) {
-            foreach ($conditions as $key => $condition) {
-                if (!is_array($condition[0])) {
-                    $evaluator->addCondition(...$condition);
-                }else {
-                  $evaluator->addGroup($condition, (string)$key);
-                }
-
-            }
-        }, $connector, $negate);
+        return $this->_group(
+            fn($evaluator) => $evaluator->addConditions($conditions),
+            $connector,
+            $negate
+        );
     }
 
     public function addConditions(array $conditions)
     {
         foreach ($conditions as $key => $condition) {
 
-            if (!is_array($condition[0])) {
-                $this->addCondition(...$condition);
-            }else {
+            $conditionType = $condition['type'] ?? null;
 
-                $groupConnector = Evaluator::AND_CONNECTOR;
+            if ($conditionType === self::TYPE_CONDITION) {
+                $condition = array_merge($this->getConditionDefaults(), $condition);
 
-                if (is_string($key) && in_array($key, [Evaluator::AND_CONNECTOR, Evaluator::OR_CONNECTOR])) {
-                    $groupConnector = \strtolower($key);
+                $this->addCondition(
+                    $condition['condition'],
+                    $condition['args'],
+                    $condition['connector'],
+                    $condition['negate']
+                );
+            } else if ($conditionType == self::TYPE_GROUP) {
+                $conditionGroup = array_merge($this->getGroupDefaults(), $condition);
+
+                if (count($conditionGroup['conditions']) > 0) {
+                    $this->addGroup(
+                        $conditionGroup['conditions'],
+                        $conditionGroup['connector'],
+                        $conditionGroup['negate']
+                    );
                 }
-
-                $this->addGroup($condition, $groupConnector);
+            } else {
+                //TODO maybe throw an exception
             }
         }
     }
@@ -333,5 +344,24 @@ class Evaluator
             },
             $arguments
         );
+    }
+
+    protected function getConditionDefaults(): array
+    {
+        return [
+            'condition' => null,
+            'args' => [],
+            'connector' => self::AND_CONNECTOR,
+            'negate' => false
+        ];
+    }
+
+    protected function getGroupDefaults(): array
+    {
+        return [
+            'conditions' => [],
+            'connector' => self::AND_CONNECTOR,
+            'negate' => false
+        ];
     }
 }

--- a/tests/EvaluatorTest.php
+++ b/tests/EvaluatorTest.php
@@ -20,88 +20,291 @@ final class EvaluatorTest extends TestCase
         return [
             'Two conditions are evaluate and returns expected value' => [
                 [
-                    ['equals', [1, 1], Evaluator::AND_CONNECTOR, false],
-                    ['contains', ["Hello", "ll"], Evaluator::AND_CONNECTOR, false],
+                    [
+                        'type' => 'condition',
+                        'condition' => 'equals',
+                        'args' => [1, 1],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ],
+                    [
+                        'type' => 'condition',
+                        'condition' => 'contains',
+                        'args' => ["Hello", "ll"],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ],
                 ],
                 true
             ],
             'Conditions are grouped correctly' => [
                 [
-                    ['equals', [1, 2], Evaluator::AND_CONNECTOR, false],
-                    ['contains', ["Hello", "b"], Evaluator::AND_CONNECTOR, false],
-                    ['match', ["condition", "tio(n|nal)"], Evaluator::OR_CONNECTOR, false],
+                    [
+                        'type' => 'condition',
+                        'condition' => 'equals',
+                        'args' => [1, 2],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ],
+                    [
+                        'type' => 'condition',
+                        'condition' => 'contains',
+                        'args' => ["Hello", "b"],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ],
+                    [
+                        'type' => 'condition',
+                        'condition' => 'match',
+                        'args' => ["condition", "tio(n|nal)"],
+                        'connector' => Evaluator::OR_CONNECTOR,
+                        'negate' => false
+                    ],
                 ],
                 true
             ],
             'Groups are created manually' => [
                 [
-                    ['equals', [1, 2], Evaluator::AND_CONNECTOR, false],
-                    'and' => [
-                        ['contains', ["Hello", "b"], Evaluator::AND_CONNECTOR, false],
-                        ['match', ["condition", "tio(n|nal)"], Evaluator::OR_CONNECTOR, false]
+                    [
+                        'type' => 'condition',
+                        'condition' => 'equals',
+                        'args' => [1, 2],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ],
+                    [
+                        'type' => 'group',
+                        'conditions' => [
+                            [
+                                'type' => 'condition',
+                                'condition' => 'contains',
+                                'args' => ["Hello", "b"],
+                                'connector' => Evaluator::AND_CONNECTOR,
+                                'negate' => false
+                            ],
+                            [
+                                'type' => 'condition',
+                                'condition' => 'match',
+                                'args' => ["condition", "tio(n|nal)"],
+                                'connector' => Evaluator::OR_CONNECTOR,
+                                'negate' => false
+                            ]
+                        ],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
                     ],
                 ],
                 false
             ],
             'Nested groups can be added manually' => [
                 [
-                    ['equals', [1, 2], Evaluator::AND_CONNECTOR, false],
-                    'and' => [
-                        ['contains', ["Hello", "b"], Evaluator::AND_CONNECTOR, false],
-                        ['match', ["condition", "tio(n|nal)"], Evaluator::OR_CONNECTOR, false],
-                        'or' => [
-                            ['endsWith', ["PHP", "HP"], Evaluator::AND_CONNECTOR, false],
-                            ['startsWith', ["PHP", "PH"], Evaluator::OR_CONNECTOR, false],
-                        ]
+                    [
+                        'type' => 'condition',
+                        'condition' => 'equals',
+                        'args' => [1, 2],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ],
+                    [
+                        'type' => 'group',
+                        'conditions' => [
+                            [
+                                'type' => 'condition',
+                                'condition' => 'contains',
+                                'args' => ["Hello", "b"],
+                                'connector' => Evaluator::AND_CONNECTOR,
+                                'negate' => false
+                            ],
+                            [
+                                'type' => 'condition',
+                                'condition' => 'match',
+                                'args' => ["condition", "tio(n|nal)"],
+                                'connector' => Evaluator::OR_CONNECTOR,
+                                'negate' => false
+                            ],
+                            [
+                                'type' => 'group',
+                                'conditions' => [
+                                    [
+                                        'type' => 'condition',
+                                        'condition' => 'endsWith',
+                                        'args' => ["PHP", "HP"],
+                                        'connector' => Evaluator::AND_CONNECTOR,
+                                        'negate' => false
+                                    ],
+                                    [
+                                        'type' => 'condition',
+                                        'condition' => 'startsWith',
+                                        'args' => ["PHP", "PH"],
+                                        'connector' => Evaluator::OR_CONNECTOR,
+                                        'negate' => false
+                                    ]
+                                ],
+                                'connector' => Evaluator::OR_CONNECTOR,
+                                'negate' => false
+                            ]
+                        ],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
                     ],
                 ],
                 false
             ],
             'N groups can be added nested' => [
                 [
-                    ['equals', [1, 2], Evaluator::AND_CONNECTOR, false],
-                    'and' => [
-                        ['contains', ["Hello", "b"], Evaluator::AND_CONNECTOR, false],
-                        ['match', ["condition", "tio(n|nal)"], Evaluator::OR_CONNECTOR, false],
-                        'or' => [
-                            ['endsWith', ["PHP", "HP"], Evaluator::AND_CONNECTOR, false],
-                            ['startsWith', ["PHP", "PH"], Evaluator::OR_CONNECTOR, false],
-                        ]
+                    [
+                        'type' => 'condition',
+                        'condition' => 'equals',
+                        'args' => [1, 2],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ],
+                    [
+                        'type' => 'group',
+                        'conditions' => [
+                            [
+                                'type' => 'condition',
+                                'condition' => 'contains',
+                                'args' => ["Hello", "b"],
+                                'connector' => Evaluator::AND_CONNECTOR,
+                                'negate' => false
+                            ],
+                            [
+                                'type' => 'condition',
+                                'condition' => 'match',
+                                'args' => ["condition", "tio(n|nal)"],
+                                'connector' => Evaluator::OR_CONNECTOR,
+                                'negate' => false
+                            ],
+                            [
+                                'type' => 'group',
+                                'conditions' => [
+                                    [
+                                        'type' => 'condition',
+                                        'condition' => 'endsWith',
+                                        'args' => ["PHP", "HP"],
+                                        'connector' => Evaluator::AND_CONNECTOR,
+                                        'negate' => false
+                                    ],
+                                    [
+                                        'type' => 'condition',
+                                        'condition' => 'startsWith',
+                                        'args' => ["PHP", "PH"],
+                                        'connector' => Evaluator::OR_CONNECTOR,
+                                        'negate' => false
+                                    ]
+                                ],
+                                'connector' => Evaluator::OR_CONNECTOR,
+                                'negate' => false
+                            ]
+                        ],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
                     ],
                 ],
                 false
             ],
             'Deeply nested conditions' => [
                 [
-                    ['equals', [1, 1], Evaluator::AND_CONNECTOR, false],
-                    'and' => [
-                        ['contains', ["Hello", "H"], Evaluator::AND_CONNECTOR, false],
-                        'or' => [
-                            ['match', ["condition", "tio(n|nal)"], Evaluator::OR_CONNECTOR, false],
-                            'and' => [
-                                ['endsWith', ["PHP", "HP"], Evaluator::AND_CONNECTOR, false],
-                                'or' => [
-                                    ['startsWith', ["PHP", "PH"], Evaluator::OR_CONNECTOR, false],
-                                    'and' => [
-                                        ['gt', [10, 5], Evaluator::AND_CONNECTOR, false],
-                                        ['lt', [5, 10], Evaluator::AND_CONNECTOR, false],
-                                    ],
-                                ],
-                            ],
-                        ],
+                    [
+                        'type' => 'condition',
+                        'condition' => 'equals',
+                        'args' => [1, 1],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
                     ],
+                    [
+                        'type' => 'group',
+                        'conditions' => [
+                            [
+                                'type' => 'condition',
+                                'condition' => 'contains',
+                                'args' => ["Hello", "H"],
+                                'connector' => Evaluator::AND_CONNECTOR,
+                                'negate' => false
+                            ],
+                            [
+                                'type' => 'group',
+                                'conditions' => [
+                                    [
+                                        'type' => 'condition',
+                                        'condition' => 'match',
+                                        'args' => ["condition", "tio(n|nal)"],
+                                        'connector' => Evaluator::OR_CONNECTOR,
+                                        'negate' => false
+                                    ],
+                                    [
+                                        'type' => 'group',
+                                        'conditions' => [
+                                            [
+                                                'type' => 'condition',
+                                                'condition' => 'endsWith',
+                                                'args' => ["PHP", "HP"],
+                                                'connector' => Evaluator::AND_CONNECTOR,
+                                                'negate' => false
+                                            ],
+                                            [
+                                                'type' => 'group',
+                                                'conditions' => [
+                                                    [
+                                                        'type' => 'condition',
+                                                        'condition' => 'startsWith',
+                                                        'args' => ["PHP", "PH"],
+                                                        'connector' => Evaluator::OR_CONNECTOR,
+                                                        'negate' => false
+                                                    ],
+                                                    [
+                                                        'type' => 'group',
+                                                        'conditions' => [
+                                                            [
+                                                                'type' => 'condition',
+                                                                'condition' => 'gt',
+                                                                'args' => [10, 5],
+                                                                'connector' => Evaluator::AND_CONNECTOR,
+                                                                'negate' => false
+                                                            ],
+                                                            [
+                                                                'type' => 'condition',
+                                                                'condition' => 'lt',
+                                                                'args' => [5, 10],
+                                                                'connector' => Evaluator::AND_CONNECTOR,
+                                                                'negate' => false
+                                                            ]
+                                                        ],
+                                                        'connector' => Evaluator::AND_CONNECTOR,
+                                                        'negate' => false
+                                                    ]
+                                                ],
+                                                'connector' => Evaluator::OR_CONNECTOR,
+                                                'negate' => false
+                                            ]
+                                        ],
+                                        'connector' => Evaluator::AND_CONNECTOR,
+                                        'negate' => false
+                                    ]
+                                ],
+                                'connector' => Evaluator::OR_CONNECTOR,
+                                'negate' => false
+                            ]
+                        ],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => false
+                    ]
                 ],
                 true
             ],
             'Negated condition returns true' => [
                 [
                     [
-                        ['equals', [1, 2], Evaluator::AND_CONNECTOR, true],
-                    ],
+                        'type' => 'condition',
+                        'condition' => 'equals',
+                        'args' => [1, 2],
+                        'connector' => Evaluator::AND_CONNECTOR,
+                        'negate' => true
+                    ]
                 ],
                 true
             ],
-
         ];
     }
 
@@ -149,18 +352,24 @@ final class EvaluatorTest extends TestCase
         $this->evaluator->setDataSource($product)
             ->addConditions([
                 [
-                    'gt',
-                    [
+                    'type' => 'condition',
+                    'condition' => 'gt',
+                    'args' => [
                         '@@ratings.totalReviews',
                         100
-                    ]
+                    ],
+                    'connector' => Evaluator::AND_CONNECTOR,
+                    'negate' => false
                 ],
                 [
-                    'contains',
-                    [
+                    'type' => 'condition',
+                    'condition' => 'contains',
+                    'args' => [
                         '@@resolution',
                         '2160'
-                    ]
+                    ],
+                    'connector' => Evaluator::AND_CONNECTOR,
+                    'negate' => false
                 ]
             ]);
 
@@ -195,18 +404,24 @@ final class EvaluatorTest extends TestCase
         $this->evaluator->setDataSource($product)
             ->addConditions([
                 [
-                    'gt',
-                    [
+                    'type' => 'condition',
+                    'condition' => 'gt',
+                    'args' => [
                         '@@ratings.missingProperty',
                         100
-                    ]
+                    ],
+                    'connector' => Evaluator::AND_CONNECTOR,
+                    'negate' => false
                 ],
                 [
-                    'contains',
-                    [
+                    'type' => 'condition',
+                    'condition' => 'contains',
+                    'args' => [
                         '@@resolution',
                         '2160'
-                    ]
+                    ],
+                    'connector' => Evaluator::AND_CONNECTOR,
+                    'negate' => false
                 ]
             ]);
 


### PR DESCRIPTION
The earlier versions of `addConditions` method to evaluators were to complex to be used. So I bring a more little change that allow us to be more structured and open to reuse. 

**Before:**

Confusing format open to  bugs since trying to match `addCondition` method on Evaluator

  ```php 
$evaluator->addConditions([
    ['equals', [1, 2], Evaluator::AND_CONNECTOR, false],
    ['contains', ["Hello", "b"], Evaluator::AND_CONNECTOR, false],
    ['match', ["condition", "tio(n|nal)"], Evaluator::OR_CONNECTOR, false],
])
```
**After:**
More clear format, easy to maintain and easy to improve.

```php
$evaluator->addConditions([
    [
        'type' => 'condition',
        'condition' => 'equals',
        'args' => [1, 2],
        'connector' => Evaluator::AND_CONNECTOR,
        'negate' => false
    ],
    [
        'type' => 'condition',
        'condition' => 'contains',
        'args' => ["Hello", "b"],
        'connector' => Evaluator::AND_CONNECTOR,
        'negate' => false
    ],
    [
        'type' => 'condition',
        'condition' => 'match',
        'args' => ["condition", "tio(n|nal)"],
        'connector' => Evaluator::OR_CONNECTOR,
        'negate' => false
    ],
]);
```
Groups are more easier to add with the same structure as above

```php
[
    'type' => 'group',
    'connector' => Evaluator::AND_CONNECTOR,
    'negate' => false,
    'conditions' => [
        [
            'type' => 'condition',
            'condition' => 'contains',
            'args' => ["Hello", "b"],
            'connector' => Evaluator::AND_CONNECTOR,
            'negate' => false
        ],
     //...more conditions
    ]
]
```